### PR TITLE
Wrong package specfied in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cleantext==1.1.3
+clean-text==0.6.0
 num2words==0.5.10
 pandas==1.4.1
 scipy==1.7.3


### PR DESCRIPTION
Hi 🙂 -- @hsiaolinh asked me to help get this code running, and in the process I needed to fix this (rather confusing) issue, so here's a PR.  Thank you!

[commit message follows:]

[`cleantext`](https://github.com/prasanthg3/cleantext) and [`clean-text`](https://github.com/jfilter/clean-text) are different packages -- unfortunately they both expose the same `from cleantext import clean` module and function names 😐.  In any event, the API invoked by the lambda functions in [`utils.py`](https://github.com/ddemszky/conversational-uptake/blob/main/utils.py#L17-L57) is the one from `clean-text`, so `requirements.txt` needs `clean-text==0.6.0` not `cleantext==1.1.3`.